### PR TITLE
Code quality fix - Utility classes should not have public constructors.

### DIFF
--- a/src/main/java/io/vertx/examples/feeds/utils/RedisUtils.java
+++ b/src/main/java/io/vertx/examples/feeds/utils/RedisUtils.java
@@ -4,6 +4,8 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.redis.RedisOptions;
 
 public class RedisUtils {
+
+	private RedisUtils() {}
 	
 	public static RedisOptions createRedisOptions(JsonObject conf) {
 		RedisOptions options = new RedisOptions();


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118

Please let me know if you have any questions.

Faisal Hameed
